### PR TITLE
Potential fix for code scanning alert no. 10: DOM text reinterpreted as HTML

### DIFF
--- a/site/_includes/docs.tsx
+++ b/site/_includes/docs.tsx
@@ -23,6 +23,34 @@ interface DocData {
 const SIDEBAR_KEY = 'docs-sidebar';
 const SCROLL_SPY_MARGIN = '-10% 0px -75% 0px';
 
+const sanitizeHref = (url: string): string => {
+  const value = url.trim();
+  if (!value) return '#';
+
+  // Allow safe in-site navigations.
+  if (
+    value.startsWith('/') ||
+    value.startsWith('./') ||
+    value.startsWith('../') ||
+    value.startsWith('#') ||
+    value.startsWith('?')
+  ) {
+    return value;
+  }
+
+  // Allow only http(s) absolute URLs.
+  try {
+    const parsed = new URL(value, window.location.origin);
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return value;
+    }
+  } catch {
+    // Invalid URL falls through to safe fallback.
+  }
+
+  return '#';
+};
+
 const slugify = (text: string) =>
   text
     .toLowerCase()
@@ -150,7 +178,7 @@ const Sidebar = ({ activeId, collapsed, onTocClick }: SidebarProps) => (
         {navItems.map(item => (
           <li key={item.url}>
             <a
-              href={item.url}
+              href={sanitizeHref(item.url)}
               className={`block rounded-lg px-3.5 py-2 text-sm font-medium transition-colors ${
                 item.active
                   ? 'relative bg-accent-glow font-semibold text-accent-bright! md:before:absolute md:before:-left-3.5 md:before:top-1/2 md:before:h-[60%] md:before:w-0.5 md:before:-translate-y-1/2 md:before:rounded-r-sm md:before:bg-accent md:before:content-[""]'


### PR DESCRIPTION
Potential fix for [https://github.com/touhidurrr/UncivServer.xyz/security/code-scanning/10](https://github.com/touhidurrr/UncivServer.xyz/security/code-scanning/10)

General fix: never bind untrusted strings directly to URL attributes. Add strict URL sanitization that allows only safe schemes (typically `http:`, `https:`, plus relative URLs), and fall back to a safe value when invalid.

Best fix here (without changing functionality beyond security hardening):
- In `site/_includes/docs.tsx`, add a helper `sanitizeHref(url: string): string`.
- Allow:
  - root-relative (`/...`), path-relative (`./...`, `../...`), fragment (`#...`), and query (`?...`) URLs.
  - absolute `http:` / `https:` URLs.
- Reject dangerous schemes (`javascript:`, `data:`, etc.) by returning `'#'`.
- Update line 153 usage from `href={item.url}` to `href={sanitizeHref(item.url)}`.

No new imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
